### PR TITLE
typo: Updating doc to match github config field name

### DIFF
--- a/website/docs/r/pipeline.md
+++ b/website/docs/r/pipeline.md
@@ -21,7 +21,7 @@ resource "buildkite_pipeline" "build_something" {
   default_branch = "master"
   repository     = "git@github.com:my-org/awesome-repo.git"
   
-  github {
+  github_settings {
     build_pull_request_forks = true
   }
 


### PR DESCRIPTION
As per current code label https://github.com/Canva/terraform-provider-buildkite/blob/ab94670a3f7ba016ae3172559d0419a17a73172e/buildkite/provider/resource_pipeline.go#L193