### PR TITLE
Fixing pipline team references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 ./terraform-provider-buildkite
 .idea
+terraform/

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 set -ex
 IFS=$' \n\t'
 
-export PROVIDER_VERSION="0.3.0"
+export PROVIDER_VERSION="0.4.0"
 export DISTDIR="$PWD/dist"
 export WORKDIR="$PWD"
 

--- a/buildkite/client/team_pipeline.go
+++ b/buildkite/client/team_pipeline.go
@@ -1,9 +1,10 @@
 package client
 
 import (
+	"log"
+
 	"github.com/machinebox/graphql"
 	"github.com/pkg/errors"
-	"log"
 )
 
 const (
@@ -69,7 +70,7 @@ query GetTeamPipeline($teamPipelineId: ID!) {
 
 	response := teamPipelineResponse{}
 	if err := c.graphQLRequest(req, &response); err != nil {
-		return nil, errors.Wrapf(err, "failed to get team member %s", teamPipelineId)
+		return nil, errors.Wrapf(err, "failed to get team pipeline %s", teamPipelineId)
 	}
 
 	return &response.TeamPipeline, nil

--- a/buildkite/provider/resource_pipeline.go
+++ b/buildkite/provider/resource_pipeline.go
@@ -77,6 +77,7 @@ var (
 		"team_uuids": {
 			Type:     schema.TypeSet,
 			Optional: true,
+			Computed: true,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},


### PR DESCRIPTION
This sets the team uuids for a pipeline to be computed so that the provider doesn't attempt to rebuild pipelines when teams are assigned and allows teams to be created with custom access levels. 

Changes to .gitignore and build.sh are suggestions.  Likewise whitespace changes suggested by my editor. 

Some logging improvements to wording. 