### PR TITLE
set teams default pipeline creation permission to false, can be passed via members_can_create_pipelines in terraform

### DIFF
--- a/buildkite/client/team.go
+++ b/buildkite/client/team.go
@@ -18,15 +18,16 @@ type teamResponse struct {
 }
 
 type Team struct {
-	Id                string `json:"id,omitempty"`
-	UUID              string `json:"uuid,omitempty"`
-	Slug              string `json:"slug,omitempty"`
-	Name              string `json:"name,omitempty"`
-	Description       string `json:"description,omitempty"`
-	Privacy           string `json:"privacy,omitempty"`
-	IsDefaultTeam     bool   `json:"isDefaultTeam,omitempty"`
-	DefaultMemberRole string `json:"defaultMemberRole,omitempty"`
-	CreatedAt         string `json:"createdAt,omitempty"`
+	Id                          string `json:"id,omitempty"`
+	UUID                        string `json:"uuid,omitempty"`
+	Slug                        string `json:"slug,omitempty"`
+	Name                        string `json:"name,omitempty"`
+	Description                 string `json:"description,omitempty"`
+	Privacy                     string `json:"privacy,omitempty"`
+	IsDefaultTeam               bool   `json:"isDefaultTeam,omitempty"`
+	DefaultMemberRole           string `json:"defaultMemberRole,omitempty"`
+	CreatedAt                   string `json:"createdAt,omitempty"`
+	MembersCanCreatePipelines   bool   `json:"membersCanCreatePipelines,omitempty"`
 }
 
 type teamCreateResponse struct {
@@ -60,6 +61,7 @@ query GetTeam($teamSlug: ID!) {
     privacy
     isDefaultTeam
     defaultMemberRole
+    membersCanCreatePipelines
   }
 }`)
 	req.Var("teamSlug", c.createOrgSlug(slug))
@@ -93,19 +95,21 @@ mutation TeamNewMutation($teamCreateInput: TeamCreateInput!) {
         privacy
         isDefaultTeam
         defaultMemberRole
+        membersCanCreatePipelines
       }
     }
   }
 }
 `)
 
-	req.Var("teamCreateInput", map[string]interface{}{
-		"organizationID":    orgId,
-		"name":              team.Name,
-		"description":       team.Description,
-		"isDefaultTeam":     team.IsDefaultTeam,
-		"defaultMemberRole": team.DefaultMemberRole,
-		"privacy":           team.Privacy,
+	req.Var("teamUpdateInput", map[string]interface{}{
+		"id":                           team.Id,
+		"name":                         team.Name,
+		"description":                  team.Description,
+		"isDefaultTeam":                team.IsDefaultTeam,
+		"defaultMemberRole":            team.DefaultMemberRole,
+		"privacy":                      team.Privacy,
+		"membersCanCreatePipelines":    team.MembersCanCreatePipelines,
 	})
 
 	teamCreateResponse := teamCreateResponse{}
@@ -131,18 +135,20 @@ mutation TeamUpdateMutation($teamUpdateInput: TeamUpdateInput!) {
       privacy
       isDefaultTeam
       defaultMemberRole
+      membersCanCreatePipelines
     }
   }
 }
 `)
 
 	req.Var("teamUpdateInput", map[string]interface{}{
-		"id":                team.Id,
-		"name":              team.Name,
-		"description":       team.Description,
-		"isDefaultTeam":     team.IsDefaultTeam,
-		"defaultMemberRole": team.DefaultMemberRole,
-		"privacy":           team.Privacy,
+		"id":                           team.Id,
+		"name":                         team.Name,
+		"description":                  team.Description,
+		"isDefaultTeam":                team.IsDefaultTeam,
+		"defaultMemberRole":            team.DefaultMemberRole,
+		"privacy":                      team.Privacy,
+		"membersCanCreatePipelines":    team.MembersCanCreatePipelines,
 	})
 
 	teamUpdateResponse := teamUpdateResponse{}

--- a/buildkite/provider/resource_team.go
+++ b/buildkite/provider/resource_team.go
@@ -67,6 +67,11 @@ func resourceTeam() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"members_can_create_pipelines": {
+			    Type:     schema.TypeBool,
+			    Optional: true,
+			    Default:  false,
+			},
 		},
 	}
 }
@@ -141,6 +146,7 @@ func updateTeamFromAPI(d *schema.ResourceData, t *client.Team) error {
 	d.Set("privacy", t.Privacy)
 	d.Set("is_default_team", t.IsDefaultTeam)
 	d.Set("default_member_role", t.DefaultMemberRole)
+	d.Set("members_can_create_pipelines", t.MembersCanCreatePipelines)
 
 	return nil
 }
@@ -161,6 +167,7 @@ func prepareTeamRequestPayload(d *schema.ResourceData) *client.Team {
 	req.CreatedAt = d.Get("created_at").(string)
 	req.IsDefaultTeam = d.Get("is_default_team").(bool)
 	req.DefaultMemberRole = d.Get("default_member_role").(string)
+	req.MembersCanCreatePipelines = d.Get("members_can_create_pipelines").(bool)
 
 	return req
 }


### PR DESCRIPTION
set teams default pipeline creation permission to false, can be passed via members_can_create_pipelines in terraform
This feature is required to control teams default permissions to create pipelines. Members then cant create pipelines directly through buildkite UI instead, they need to follow our automation process to create a new pipeline in buildkite.

If otherwise we need to set this to true it can be passed via members_can_create_pipelines = true while creating buildkite_teams in terraform