### PR TITLE
[FEIN-695] migrate "pipeline" from `team_uuids` to `team_ids` argument

### DIFF
--- a/buildkite/client/pipeline.go
+++ b/buildkite/client/pipeline.go
@@ -245,8 +245,8 @@ query Pipeline($slug: ID!) {
 	}
 
 	teamIDs := make([]string, len(resp.Pipeline.Teams.Edges))
-	for i, ID := range resp.Pipeline.Teams.Edges {
-		teamIDs[i] = ID.Node.Team.ID
+	for i, edge := range resp.Pipeline.Teams.Edges {
+		teamIDs[i] = edge.Node.Team.ID
 	}
 	log.Printf("[TRACE] got team ids: %v", teamIDs)
 	return teamIDs, nil

--- a/buildkite/provider/resource_pipeline.go
+++ b/buildkite/provider/resource_pipeline.go
@@ -74,7 +74,7 @@ var (
 			Optional:      true,
 			ConflictsWith: []string{"step", "env"},
 		},
-		"team_uuids": {
+		"team_ids": {
 			Type:     schema.TypeSet,
 			Optional: true,
 			Elem: &schema.Schema{
@@ -315,9 +315,9 @@ func UpdatePipeline(d *schema.ResourceData, meta interface{}) error {
 
 	buildkiteClient := meta.(*client.Client)
 
-	pipeline, teamUUIDsHaveChanged := preparePipelineRequestPayload(d)
-	if teamUUIDsHaveChanged {
-		return errors.New("unable to update 'team_uuids', consider to delete the pipeline and create the new one")
+	pipeline, teamIDsHaveChanged := preparePipelineRequestPayload(d)
+	if teamIDsHaveChanged {
+		return errors.New("unable to update 'team_ids', consider to delete the pipeline and create the new one")
 	}
 
 	res, err := buildkiteClient.UpdatePipeline(pipeline)
@@ -351,8 +351,8 @@ func updatePipelineFromAPI(d *schema.ResourceData, p *client.Pipeline) error {
 	d.Set("branch_configuration", p.BranchConfiguration)
 	d.Set("default_branch", p.DefaultBranch)
 	d.Set("configuration", p.Configuration)
-	d.Set("team_uuids", p.TeamUUIDs)
-	log.Printf("[TRACE] set pipeline team uuids: %v", p.TeamUUIDs)
+	d.Set("team_ids", p.TeamIDs)
+	log.Printf("[TRACE] set pipeline team uuids: %v", p.TeamIDs)
 
 	stepMap := make([]interface{}, len(p.Steps))
 	for i, element := range p.Steps {
@@ -458,12 +458,12 @@ func preparePipelineRequestPayload(d *schema.ResourceData) (*client.Pipeline, bo
 	for k, vI := range d.Get("env").(map[string]interface{}) {
 		req.Environment[k] = vI.(string)
 	}
-	teamUUIDs := d.Get("team_uuids").(*schema.Set).List()
-	req.TeamUUIDs = make([]string, len(teamUUIDs))
-	for i, t := range teamUUIDs {
-		req.TeamUUIDs[i] = t.(string)
+	teamIDs := d.Get("team_ids").(*schema.Set).List()
+	req.TeamIDs = make([]string, len(teamIDs))
+	for i, t := range teamIDs {
+		req.TeamIDs[i] = t.(string)
 	}
-	log.Printf("[TRACE] pull team uuids from schema: %v", req.TeamUUIDs)
+	log.Printf("[TRACE] pull team ids from schema: %v", req.TeamIDs)
 
 	if val, ok := d.GetOk("configuration"); ok {
 		req.Configuration = val.(string)
@@ -512,5 +512,5 @@ func preparePipelineRequestPayload(d *schema.ResourceData) (*client.Pipeline, bo
 		req.ProviderSettings = settings
 	}
 
-	return req, d.HasChange("team_uuids")
+	return req, d.HasChange("team_ids")
 }

--- a/website/docs/r/pipeline.md
+++ b/website/docs/r/pipeline.md
@@ -25,6 +25,8 @@ resource "buildkite_pipeline" "build_something" {
     build_pull_request_forks = true
   }
 
+  team_ids = [var.a_team_id]
+
   step {
     name    = ":pipeline: Fetch pipeline"
     type    = "script"
@@ -51,6 +53,8 @@ The following arguments are supported:
 * `default_branch` - (Optional) the default branch to build. Defaults to `master`
 
 * `env` - (Optional) pipeline environment variables
+
+* `team_ids` - (Optional) an array of team ids to associate given pipeline with. Buildkite doesn't allow you to create a pipeline if you not an admin or if you a member of more that one team or none of them. This argument is needed to address this issue.
 
 * `step` - (Required) nested block list configuring the steps to run. Must provide at least one.
 

--- a/website/docs/r/pipeline.md
+++ b/website/docs/r/pipeline.md
@@ -54,7 +54,7 @@ The following arguments are supported:
 
 * `env` - (Optional) pipeline environment variables
 
-* `team_ids` - (Optional) an array of team ids to associate given pipeline with. Buildkite doesn't allow you to create a pipeline if you not an admin or if you a member of more that one team or none of them. This argument is needed to address this issue.
+* `team_ids` - (Optional) a list of team ids to associate given pipeline with. Buildkite doesn't allow you to create a pipeline if you not an admin or if you a member of more that one team or none of them. This argument is needed to address this issue.
 
 * `step` - (Required) nested block list configuring the steps to run. Must provide at least one.
 


### PR DESCRIPTION
### Motivation

The `team_uuids` argument for a pipeline creation is an argument that is being supported by [Buildkite Rest API][REST] only. In the situation when the [`yaml`][yaml] steps definition is enabled by default for an organization it's no longer possible to use [Rest API][REST] to create new pipelines so we have to use GraphQL API instead because the [`yaml`][yaml] configuration can be sent via [GraphQL API][GQL] only. With that, due to the [GraphQL API][GQL] doesn't support the `team_uuids` argument, we migrate the provider to accept direct team identifiers that are being supported by [GraphQL API][GQL]. 

Previously, it was working because we have been using the undocumented Buildkite convention on how to get a team identifier from its UUID, look at [this](https://github.com/Canva/terraform-provider-buildkite/blob/cd0e5b1abd7fa00304c8f548c464c063fe0fbe72/buildkite/client/pipeline.go#L284-L294) block of code for more context. So this PR removes the undocumented Buildkite convention use.


[yaml]: https://buildkite.com/docs/tutorials/pipeline-upgrade#using-yaml-steps-for-new-pipelines
[REST]: https://buildkite.com/docs/apis/rest-api/pipelines
[GQL]: https://buildkite.com/docs/apis/graphql-api

/cc @belugarciafava, @uri-canva, @joscha

---

[Jira Ticket](https://canvadev.atlassian.net/browse/FEIN-695) | https://github.com/Canva/infrastructure/pull/17676 - migration of the `Canva/infrastructure` repository to use the new provider API.