### PR TITLE
Adds deprecation notice for 'env' and 'step' in buildkite_pipeline

### DIFF
--- a/buildkite/provider/resource_pipeline.go
+++ b/buildkite/provider/resource_pipeline.go
@@ -64,6 +64,9 @@ var (
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
+			Deprecated: "The 'env' attribute is deprecated and it will be removed in future releases. " +
+				"Please, use the 'configuration' attribute to define the pipeline in YAML format. " +
+				"See: https://buildkite.com/docs/tutorials/pipeline-upgrade",
 		},
 		"webhook_url": {
 			Type:     schema.TypeString,
@@ -135,6 +138,9 @@ var (
 					},
 				},
 			},
+			Deprecated: "The 'step' attribute is deprecated and it will be removed in future releases. " +
+				"Please, use the 'configuration' attribute to define the pipeline in YAML format. " +
+				"See: https://buildkite.com/docs/tutorials/pipeline-upgrade",
 		},
 		"bitbucket_settings": {
 			Type:          schema.TypeList,


### PR DESCRIPTION
## Intent
To add deprecation notice on both `env` and `step` fields.

https://canva.slack.com/archives/C0146S11QLW/p1608259419366900

## Problem
We have added support for `YAML` pipelines but people usually copy-paste from existing code and, thus, create pipelines using the old and deprecated approach.

## Solution
This PR adds a deprecation warning that hopefully will instruct people to use the `configuration` field instead of the `env` and `step` fields.

That way, the usage of these deprecated fields should start to decrease and, perhaps in the future, we can completely remove them.